### PR TITLE
Feature: Custom Alphabet Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ To use the plugin require the lua module with
 inside your `init.lua`
 
 
-To configure options pass a table to the setup function like the example below:
+### Ergonomic Alphabet Option
+To switch the default buffer labels from `abcd...` to `asdf...`, the `ergonmic_alphabet` option can be passed as a
+table to the setup function like the example below:
 
-`require "quick_buffer_jump".setup{ alphabet = "asdf" }`
+`require "quick_buffer_jump".setup{ ergonmic_alphabet = true }`
 
-**Note: the alphabet can't contain 'j','k','q' as these are reserved for plugin functionality**
 
 ## Usage Instructions
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ To use the plugin require the lua module with
 
 inside your `init.lua`
 
+
+To configure options pass a table to the setup function like the example below:
+
+`require "quick_buffer_jump".setup{ alphabet = "qwerty" }`
+
 ## Usage Instructions
 
 Upon typing `:QuickBufferJump`, the Quick Buffer Jump floating window will display a list of all open buffers. To navigate to a specific buffer, you can use the `j` and `k` keys, or employ a preferred jumping plugin such as Easy Motion or Leap. Once you have moved the cursor to the desired buffer, press Enter to open it.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ inside your `init.lua`
 
 To configure options pass a table to the setup function like the example below:
 
-`require "quick_buffer_jump".setup{ alphabet = "qwerty" }`
+`require "quick_buffer_jump".setup{ alphabet = "asdf" }`
+
+**Note: the alphabet can't contain 'j','k','q' as these are reserved for plugin functionality**
 
 ## Usage Instructions
 

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -1,11 +1,23 @@
 local M = {}
 
 M.config = {
-    alphabet = "abcdefghijklmnopqrstuvwxyz",
+    alphabet = "abcdefghilmnoprstuvwxyz",
 }
 
 M.setup = function(params)
-  M.config = vim.tbl_deep_extend('force', {}, M.config, params)
+    vim.validate({ params = { params, 'table',true}, alphabet = {params.alphabet,'string',true} })
+    M.config = vim.tbl_deep_extend('force', {}, M.config, params)
+
+    vim.validate({ alphabet = { params.alphabet, function()
+
+        if string.find(M.config.alphabet, "[qjk]", 1, false) then
+            M.config.alphabet = string.gsub(M.config.alphabet,"[qjk]+","")
+
+            return false, "quick_buffer_jump error: the alphabet can't contain `q`,`j`, or `k`"
+        end
+        return true
+    end}
+    })
 end
 
 -- Define a highlight group for the alphabet label

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -21,7 +21,7 @@ M.setup = function(params)
     M.config = vim.tbl_deep_extend('force', {}, M.config, params)
 
     if params.ergonomic_alphabet then
-        local alt_alphabet = "asdfhlbcegimnoprtuvwxyz"
+        local alt_alphabet = "asdfghlbceimnoprtuvwxyz"
         M.config.alphabet = alt_alphabet
     end
 

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -5,28 +5,16 @@ M.config = {
     ergonomic_alphabet = false
 }
 
-function M.validateAlphabet()
-    if string.find(M.config.alphabet, "[qjk]", 1, false) then
-        M.config.alphabet = string.gsub(M.config.alphabet,"[qjk]+","")
-
-        return false, "quick_buffer_jump error: the alphabet can't contain `q`,`j`, or `k`"
-    end
-    return true
-end
-
-
--- Verify Options are of the correct type and valid
 M.setup = function(params)
     vim.validate({ params = { params, 'table',true} })
     M.config = vim.tbl_deep_extend('force', {}, M.config, params)
+
+    vim.validate({ ergonomic_alphabet = { params.ergonomic_alphabet,'boolean' }} )
 
     if params.ergonomic_alphabet then
         local alt_alphabet = "asdfghlbceimnoprtuvwxyz"
         M.config.alphabet = alt_alphabet
     end
-
-    vim.validate({ ergonomic_alphabet = { params.ergonomic_alphabet,'boolean' }} )
-    vim.validate({ alphabet = { params.alphabet, M.validateAlphabet }} )
 
 end
 

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -2,22 +2,32 @@ local M = {}
 
 M.config = {
     alphabet = "abcdefghilmnoprstuvwxyz",
+    ergonomic_alphabet = false
 }
 
+function M.validateAlphabet()
+    if string.find(M.config.alphabet, "[qjk]", 1, false) then
+        M.config.alphabet = string.gsub(M.config.alphabet,"[qjk]+","")
+
+        return false, "quick_buffer_jump error: the alphabet can't contain `q`,`j`, or `k`"
+    end
+    return true
+end
+
+
+-- Verify Options are of the correct type and valid
 M.setup = function(params)
-    vim.validate({ params = { params, 'table',true}, alphabet = {params.alphabet,'string',true} })
+    vim.validate({ params = { params, 'table',true} })
     M.config = vim.tbl_deep_extend('force', {}, M.config, params)
 
-    vim.validate({ alphabet = { params.alphabet, function()
+    if params.ergonomic_alphabet then
+        local alt_alphabet = "asdfhlbcegimnoprtuvwxyz"
+        M.config.alphabet = alt_alphabet
+    end
 
-        if string.find(M.config.alphabet, "[qjk]", 1, false) then
-            M.config.alphabet = string.gsub(M.config.alphabet,"[qjk]+","")
+    vim.validate({ ergonomic_alphabet = { params.ergonomic_alphabet,'boolean' }} )
+    vim.validate({ alphabet = { params.alphabet, M.validateAlphabet }} )
 
-            return false, "quick_buffer_jump error: the alphabet can't contain `q`,`j`, or `k`"
-        end
-        return true
-    end}
-    })
 end
 
 -- Define a highlight group for the alphabet label

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -1,9 +1,7 @@
 local M = {}
 
 M.config = {
-  opts = {
     alphabet = "abcdefghijklmnopqrstuvwxyz",
-  },
 }
 
 M.setup = function(params)
@@ -19,7 +17,7 @@ function M.quick_buffer_jump()
     local buffers = api.nvim_list_bufs()
     local lines = {}
     local buffer_map = {}  -- Table to map line numbers to buffer numbers
-    local alphabet = M.config.opts.alphabet
+    local alphabet = M.config.alphabet
     local alphabet_count = 1
 
     -- Create buffer for the floating window

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -9,7 +9,7 @@ M.setup = function(params)
     vim.validate({ params = { params, 'table',true} })
     M.config = vim.tbl_deep_extend('force', {}, M.config, params)
 
-    vim.validate({ ergonomic_alphabet = { params.ergonomic_alphabet,'boolean' }} )
+    vim.validate({ ergonomic_alphabet = { params.ergonomic_alphabet,{'boolean', 'nil'} }} )
 
     if params.ergonomic_alphabet then
         local alt_alphabet = "asdfghlbceimnoprtuvwxyz"

--- a/lua/quick_buffer_jump.lua
+++ b/lua/quick_buffer_jump.lua
@@ -1,5 +1,15 @@
 local M = {}
 
+M.config = {
+  opts = {
+    alphabet = "abcdefghijklmnopqrstuvwxyz",
+  },
+}
+
+M.setup = function(params)
+  M.config = vim.tbl_deep_extend('force', {}, M.config, params)
+end
+
 -- Define a highlight group for the alphabet label
 vim.api.nvim_command('highlight AlphabetLabel guifg=Cyan ctermfg=Cyan')
 
@@ -9,7 +19,7 @@ function M.quick_buffer_jump()
     local buffers = api.nvim_list_bufs()
     local lines = {}
     local buffer_map = {}  -- Table to map line numbers to buffer numbers
-    local alphabet = 'abcdefghilmnoprstuvwxyz'
+    local alphabet = M.config.opts.alphabet
     local alphabet_count = 1
 
     -- Create buffer for the floating window


### PR DESCRIPTION
This PR introduces the option to add a custom alphabet as requested and resolves #3. 

The option can be set in the following way `require "quick_buffer_jump".setup{ alphabet = "qwerty" }` and will default to `"abcdefghijklmnopqrstuvwxyz"` if not specified.